### PR TITLE
Added submodule theme4/XS101/CHAP-Training-Examples-Materials

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "theme4/XS101/CHAP-Training-Examples-Materials"]
+	path = theme4/XS101/CHAP-Training-Examples-Materials
+	url = git@github.com:CHESSComputing/CHAP-Training-Examples-Materials.git


### PR DESCRIPTION
The repo with hands-on tutorial examples for XS101 (https://github.com/CHESSComputing/CHAP-Training-Examples-Materials.git) was added as a submodule to the theme4/XS101 folder.