### PR TITLE
Enable tinytex on CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tinytex: true
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,5 +24,11 @@ jobs:
       - name: Set up TeXLive
         uses: teatimeguest/setup-texlive-action@v3
 
+      - name: Check `tlmgr` version
+        run: tlmgr --version
+
+      - name: Check quarto version
+        run: quarto --version
+
       - name: Render Quarto Project
         uses: quarto-dev/quarto-actions/render@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          tinytex: true
 
       - name: Render Quarto Project
         uses: quarto-dev/quarto-actions/render@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,11 +21,11 @@ jobs:
         with:
           tinytex: true
 
-      - name: Set up TeXLive
-        uses: teatimeguest/setup-texlive-action@v3
+      # - name: Set up TeXLive
+      #   uses: teatimeguest/setup-texlive-action@v3
 
-      - name: Check `tlmgr` version
-        run: tlmgr --version
+      # - name: Check `tlmgr` version
+      #   run: tlmgr --version
 
       - name: Check quarto version
         run: quarto --version

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,5 +21,8 @@ jobs:
         with:
           tinytex: true
 
+      - name: Set up TeXLive
+        uses: teatimeguest/setup-texlive-action@v3
+
       - name: Render Quarto Project
         uses: quarto-dev/quarto-actions/render@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,5 +30,8 @@ jobs:
       - name: Check quarto version
         run: quarto --version
 
+      - name: Print Quarto tools
+        run: quarto tools
+
       - name: Render Quarto Project
         uses: quarto-dev/quarto-actions/render@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tinytex: true
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,12 @@ jobs:
         with:
           tinytex: true
 
+      - name: Print Quarto version
+        run: quarto --version
+
+      - name: Print Quarto tools
+        run: quarto tools
+
       # Publish on Netlify (https://xcitecourse.org/ and
       # x-cite-course.netlify.app).
       - name: Render and Publish on netlify

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          tinytex: true
 
       # Publish on Netlify (https://xcitecourse.org/ and
       # x-cite-course.netlify.app).


### PR DESCRIPTION
Enable tinytex on CI so that PDF slides will be rendered.

Oddly the publish-deploy workflow [failed](https://github.com/RENCI-NRIG/X-CITE/actions/runs/9083191507/job/24961344567) during publish step, not during render step.