### PR TITLE
Use https URL for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "theme4/XS101/CHAP-Training-Examples-Materials"]
 	path = theme4/XS101/CHAP-Training-Examples-Materials
-	url = https://github.com/CHESSComputing/CHAP-Training-Examples-Materials
+	url = https://github.com/CHESSComputing/CHAP-Training-Examples-Materials.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "theme4/XS101/CHAP-Training-Examples-Materials"]
 	path = theme4/XS101/CHAP-Training-Examples-Materials
-	url = git@github.com:CHESSComputing/CHAP-Training-Examples-Materials.git
+	url = https://github.com/CHESSComputing/CHAP-Training-Examples-Materials


### PR DESCRIPTION
With `git:` URL, `git submodule init` will require an SSH pubkey.  Using `https:` URL should work more reliably.